### PR TITLE
Use normal swap files on btrfs when it's supported (#92)

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -265,9 +265,18 @@ case "$1" in
       BLOCK_SIZE=$(stat -f -c %s "${swapfc_path}")
       FSTYPE=$(get_fs_type "${swapfc_path}")
 
-      YN "${swapfc_force_use_loop}" && FSTYPE=btrfs
+      if [ "$FSTYPE" = "btrfs" ]; then
+            # if btrfs supports regular swap files(kernel version 5+), force disable COW to avoid data corruption
+            # if it doesn't, use the old swap through loop workaround
+            if [ $(uname -r | cut -d. -f1) -ge 5 ]; then
+                  swapfc_nocow=true
+            else
+                  FSTYPE="btrfs_old"
+            fi
+      fi
 
-      [ "${FSTYPE}" != btrfs ] && swapfc_force_preallocated=1
+      YN "${swapfc_force_use_loop}" && FSTYPE=btrfs_old
+      [ "${FSTYPE}" != "btrfs_old" ] && swapfc_force_preallocated=1
 
       check_ENOSPC(){
         path="$1"
@@ -311,9 +320,9 @@ case "$1" in
 
         RET="${file}"
         case "${FSTYPE}" in
-          ext2|ext3|ext4)
+          ext2|ext3|ext4|btrfs)
           ;;
-          btrfs)
+          btrfs_old)
             RET=$(losetup_w "${file}")
           ;;
           *)


### PR DESCRIPTION
* Enable regular swap files on btrfs

* Enable the old swap through loop workaround where not supported

Support for swap files on btrfs was introduced in the Linux 5.x.
Check if the kernel is older than that, and enable the old workaround if
it is

* Force disable COW on newer btrfs systems to avoid data corruption